### PR TITLE
Configure PR defaults: assignee, auto-merge, and reviewer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @yukifuji

--- a/.github/workflows/on_pull_request_target.yaml
+++ b/.github/workflows/on_pull_request_target.yaml
@@ -1,0 +1,21 @@
+on:
+  pull_request_target:
+    types: [opened, ready_for_review]
+
+jobs:
+  assign_pull_request_user_and_auto_merge:
+    if: ${{ github.event.pull_request.draft == false }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 1
+    env:
+        GH_TOKEN: ${{ secrets.PAT_FOR_ON_PULL_REQUEST }}
+        GH_REPO: ${{ github.repository }}
+        NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Assign pull request user
+        run: gh pr edit $NUMBER --add-assignee $ASSIGNEE
+        env:
+          ASSIGNEE: ${{ github.event.pull_request.user.login }}
+        if: ${{ github.event.pull_request.user.type != 'Bot' && toJSON(github.event.pull_request.assignees) == '[]' }}
+      - name: Enable auto-merge
+        run: gh pr merge $NUMBER --merge --auto


### PR DESCRIPTION
Users who only have Read permission cannot request a review. Therefore, when a pull request is created and opened (or ready-for-review), @yukifuji san becomes a reviewer automatically. In addition, we also want to merge the pull request automatically when the review is completed.